### PR TITLE
Update HKCircularProgressLayer.m

### DIFF
--- a/HKCircularProgressView/HKCircularProgressView/HKCircularProgressLayer.m
+++ b/HKCircularProgressView/HKCircularProgressView/HKCircularProgressLayer.m
@@ -368,7 +368,12 @@ typedef CGFloat (^HKConcentricProgressionFunction)(CGFloat, CGFloat);
 
     if (self.step == .0f)
     {
-        CGFloat progress = current / max;
+        CGFloat progress;
+        if (max > 0)
+            progress = current / max;
+        else
+            progress = 0;
+        
         destAngle = self.startAngle + progress * k2Pi;
         [self drawArcInContext:ctx
                     withCenter:center


### PR DESCRIPTION
Added a NaN validation on method for stability in 64-bit devices:
- (void)drawProgressInContext:(CGContextRef)ctx
                   atCenter:(CGPoint)center
                 withRadius:(CGFloat)radius
                    current:(CGFloat)current
                        max:(CGFloat)max
                 fillRadius:(CGFloat)fillRadius
